### PR TITLE
deprecate-auto-endpoint: deprecate TargetAuto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v2.2.0] — deprecate AUTO endpoint
+
+### Deprecated
+
+- `TargetAuto` — latency-based routing does not guarantee regional data placement. Use
+  `TargetUS1`, `TargetEU1`, `TargetEU2`, `TargetAP1`, `TargetAP2`, or `TargetCA1` for
+  explicit data residency control. Will be removed in a future major version.
+
 ## [v2.1.0] — v2.2 surface
 
 ### New API

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import (
 
 func main() {
     client, err := scanii.NewClient(scanii.ClientOpts{
-        Target: scanii.TargetAuto,
+        Target: scanii.TargetUS1,
         Key:    "your-api-key",
         Secret: "your-api-secret",
     })
@@ -72,13 +72,13 @@ Full API reference: <https://scanii.github.io/openapi/v22/>.
 
 | Constant | Endpoint |
 |---|---|
-| `scanii.TargetAuto` | `https://api.scanii.com` |
 | `scanii.TargetUS1` | `https://api-us1.scanii.com` |
 | `scanii.TargetEU1` | `https://api-eu1.scanii.com` |
 | `scanii.TargetEU2` | `https://api-eu2.scanii.com` |
 | `scanii.TargetAP1` | `https://api-ap1.scanii.com` |
 | `scanii.TargetAP2` | `https://api-ap2.scanii.com` |
 | `scanii.TargetCA1` | `https://api-ca1.scanii.com` |
+| ~~`scanii.TargetAuto`~~ | ~~`https://api.scanii.com`~~ — **deprecated**, does not guarantee regional data placement |
 
 For a custom or local endpoint, use `scanii.NewTarget("http://localhost:4000")`.
 
@@ -108,7 +108,7 @@ Three changes are required:
 
    ```diff
    - c := client.NewClient(&client.Opts{Target: endpoints.LATEST, Key: k, Secret: s})
-   + c, err := scanii.NewClient(scanii.ClientOpts{Target: scanii.TargetAuto, Key: k, Secret: s})
+   + c, err := scanii.NewClient(scanii.ClientOpts{Target: scanii.TargetUS1, Key: k, Secret: s})
    ```
 
 3. **Every method now takes `context.Context` as its first argument:**

--- a/target.go
+++ b/target.go
@@ -22,6 +22,10 @@ func (t Target) Endpoint() string {
 
 // Predefined regional Targets.
 var (
+	// Deprecated: TargetAuto routes to the nearest region via latency-based
+	// routing and does not guarantee which region processes your data. Use an
+	// explicit regional Target (TargetUS1, TargetEU1, etc.) for data residency
+	// compliance. Will be removed in a future major version.
 	TargetAuto = Target{endpoint: "https://api.scanii.com"}
 	TargetUS1  = Target{endpoint: "https://api-us1.scanii.com"}
 	TargetEU1  = Target{endpoint: "https://api-eu1.scanii.com"}


### PR DESCRIPTION
## Summary

- `TargetAuto` var annotated with `// Deprecated:` godoc comment pointing to the explicit regional Targets
- No version constant to bump — version is tag-only (`v2.2.0`)

Part of [uvasoftware/sdks#1](https://github.com/uvasoftware/sdks/issues/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)