### PR TITLE
Bump CI actions; relax go.mod toolchain to 1.25

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,9 +16,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go: ['1.25', '1.26']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
           cache: true

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/scanii/scanii-go
 
-go 1.26
+go 1.25


### PR DESCRIPTION
Routine CI dependency maintenance for scanii-go. **No runtime dependencies** — `go.mod` has no `require` block and that stays true.

## Changes

**GitHub Actions (latest major)**
- `actions/checkout` v4 → v7
- `actions/setup-go` v5 → v6

**go.mod toolchain directive**
- `go 1.26` → `go 1.25`

The CI matrix tests Go 1.25 and 1.26, but `go.mod` required `go >= 1.26`, so `setup-go` (which runs `GOTOOLCHAIN=local`) failed the 1.25 leg:
```
go: go.mod requires go >= 1.26 (running go 1.25.11; GOTOOLCHAIN=local)
```
Lowering the directive to `1.25` (the previous-stable leg of the matrix) makes both legs build and keeps previous-stable consumers able to use the module. This resolves the dependency-audit inconsistency between `go.mod` and `pr.yml`. No source changes required.

## Verification

Local `go vet ./...` clean; `go test -race ./...` **PASS** against the scanii-cli mock on Go 1.26.2. CI now exercises Go 1.25/1.26 × ubuntu/macos/windows with both legs green.