### PR TITLE
Bump CI actions; prep v2.2.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,9 +16,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go: ['1.25', '1.26']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
           cache: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go }}
           cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.2.1] — dependency refresh
+
+- Bumped CI actions: `actions/checkout` v4 → v7, `actions/setup-go` v5 → v7.
+- Relaxed `go.mod` directive to `go 1.25` so the previous-stable CI leg builds. No runtime dependencies — the module itself is unchanged.
+
 ## [v2.2.0] — deprecate AUTO endpoint
 
 ### Deprecated

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/scanii/scanii-go
 
-go 1.26
+go 1.25


### PR DESCRIPTION
Dependency refresh (CI only — the module has zero dependencies and is unchanged):

- `actions/checkout` v4 → v7
- `actions/setup-go` v5 → v7
- `go.mod` directive relaxed to `go 1.25` so the previous-stable CI leg (Go 1.25) builds
- CHANGELOG entry for v2.2.1 (patch — Go releases are tag-only, no manifest version)

Go matrix (1.25 / 1.26) verified current against go.dev. Local `go build`, `go vet`, and `go test` against scanii-cli: all pass.